### PR TITLE
fix(docker): install ts-node globally for production seed script

### DIFF
--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -62,6 +62,7 @@ COPY packages ./packages
 COPY apps/backend ./apps/backend
 
 RUN npm install -g pnpm@9 && \
+    npm install -g ts-node@10.9.2 @types/node@22 @types/bcrypt && \
     pnpm install --frozen-lockfile --prod && \
     cd packages/db && pnpm exec prisma generate
 

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "db:seed": "pnpm --filter @restaurant/db seed",
     "db:studio": "pnpm --filter @restaurant/db studio",
     "db:generate": "pnpm --filter @restaurant/db generate",
-    "docker:setup:dev": "docker-compose build && docker-compose up -d && sleep 15 && docker exec restaurant-backend sh -c \"cd /app/packages/db && pnpm exec prisma db push && pnpm exec prisma db seed\"",
-    "docker:setup": "docker-compose -f docker-compose.yml -f docker-compose.prod.yml build && docker-compose -f docker-compose.yml -f docker-compose.prod.yml up -d && sleep 15 && docker exec restaurant-backend sh -c \"cd /app/packages/db && pnpm exec prisma db push && pnpm exec prisma db seed\"",
+    "docker:setup:dev": "docker-compose build && docker-compose up -d && sleep 15 && docker exec restaurant-backend sh -c \"cd /app/packages/db && pnpm exec prisma db push && /usr/local/bin/ts-node --transpile-only --compiler-options '{\\\"module\\\":\\\"CommonJS\\\"}' prisma/seed.ts\"",
+    "docker:setup": "docker-compose -f docker-compose.yml -f docker-compose.prod.yml build && docker-compose -f docker-compose.yml -f docker-compose.prod.yml up -d && sleep 15 && docker exec restaurant-backend sh -c \"cd /app/packages/db && pnpm exec prisma db push && /usr/local/bin/ts-node --transpile-only --compiler-options '{\\\"module\\\":\\\"CommonJS\\\"}' prisma/seed.ts\"",
     "docker:start": "docker-compose up -d",
     "docker:start:prod": "docker-compose -f docker-compose.yml -f docker-compose.prod.yml up -d",
     "docker:stop": "docker-compose down",
@@ -27,8 +27,8 @@
     "docker:logs:backend": "docker-compose logs -f restaurant-backend",
     "docker:ps": "docker-compose ps",
     "docker:db:push": "docker exec restaurant-backend sh -c \"cd /app/packages/db && pnpm exec prisma db push\"",
-    "docker:db:seed": "docker exec restaurant-backend sh -c \"cd /app/packages/db && pnpm exec prisma db seed\"",
-    "docker:db:reset": "docker exec restaurant-backend sh -c \"cd /app/packages/db && pnpm exec prisma db push && pnpm exec prisma db seed\"",
+    "docker:db:seed": "docker exec restaurant-backend sh -c \"cd /app/packages/db && /usr/local/bin/ts-node --transpile-only --compiler-options '{\\\"module\\\":\\\"CommonJS\\\"}' prisma/seed.ts\"",
+    "docker:db:reset": "docker exec restaurant-backend sh -c \"cd /app/packages/db && pnpm exec prisma db push && /usr/local/bin/ts-node --transpile-only --compiler-options '{\\\"module\\\":\\\"CommonJS\\\"}' prisma/seed.ts\"",
     "docker:db:studio": "docker exec -it restaurant-backend sh -c \"cd /app/packages/db && pnpm exec prisma studio\""
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
Fixed production seed script failing because ts-node wasn't available.

## Problem
Production build was failing with error:
```
Cannot find module 'ts-node/dist/bin.js'
```

## Solution
1. Installed ts-node and @types/bcrypt globally in the production Dockerfile
2. Updated docker seed scripts to use globally installed ts-node with `--transpile-only` flag

## Changes
- `apps/backend/Dockerfile`: Added `npm install -g ts-node@10.9.2 @types/bcrypt`
- `package.json`: Updated docker:db:* scripts to use `/usr/local/bin/ts-node --transpile-only`